### PR TITLE
Fix: Improve asset loading, payment flow, and rotate keys

### DIFF
--- a/apps/mobile/screens/OrderListScreen.tsx
+++ b/apps/mobile/screens/OrderListScreen.tsx
@@ -91,10 +91,16 @@ export default function OrderListScreen() {
   };
 
   const renderImage = (item: any) => {
-    if (!item?.product_name) {
-      return `${IMAGE_URL}/products/defaults/no_image.png`;
-    }
-    return `${IMAGE_URL}/products/${item.product_name}/thumbnail.jpg`;
+    const folder = item.product_name
+      ?.trim()
+      ?.replace(/\s+/g, "_") // 공백 → 언더바
+      ?.replace(/__/g, "_"); // 중복 방지(optional)
+
+    const uri = `${IMAGE_URL}/products/${encodeURIComponent(
+      folder
+    )}/thumbnail.jpg`;
+
+    return uri;
   };
 
   return (

--- a/apps/mobile/screens/payment/PaymentWebviewScreen.tsx
+++ b/apps/mobile/screens/payment/PaymentWebviewScreen.tsx
@@ -1,9 +1,11 @@
 import React from "react";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { SafeAreaView, View, StyleSheet } from "react-native";
 import { Payment } from "@portone/react-native-sdk";
 import { useNavigation, useRoute } from "@react-navigation/native";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import type { RootStackParamList } from "../../navigation/RootNavigator";
+
+import CustomHeader from "../../components/CustomHeader";
 
 type Props = NativeStackScreenProps<RootStackParamList, "PaymentWebview">;
 
@@ -13,19 +15,56 @@ export default function PaymentWebviewScreen() {
   const request = route.params.params;
 
   return (
-    <SafeAreaView style={{ flex: 1, justifyContent: "center" }}>
-      <Payment
-        request={request}
-        onComplete={(result) => {
-          console.log("COMPLETE ←", JSON.stringify(result, null, 2));
-          navigation.replace("PaymentResult", { ...result, success: true });
-        }}
-        onError={(err) => {
-          // console.log("ERROR ←", err);
-          const message = (err as Error)?.message ?? "결제 오류";
-          navigation.replace("PaymentResult", { success: false, message });
-        }}
-      />
+    <SafeAreaView style={styles.container}>
+      <View style={styles.headerOverlay}>
+        <CustomHeader
+          showBackButton
+          onPressBack={() =>
+            navigation.replace("PaymentResult", {
+              success: false,
+              message: "사용자가 결제를 취소했습니다.",
+            })
+          }
+        />
+      </View>
+
+      <View style={styles.paymentWrap}>
+        <Payment
+          request={request}
+          onComplete={(result) => {
+            console.log("COMPLETE ←", JSON.stringify(result, null, 2));
+            navigation.replace("PaymentResult", { ...result, success: true });
+          }}
+          onError={(err) => {
+            const message = (err as Error)?.message ?? "결제 오류";
+            navigation.replace("PaymentResult", {
+              success: false,
+              message,
+            });
+          }}
+        />
+      </View>
     </SafeAreaView>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#fff",
+  },
+
+  headerOverlay: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    zIndex: 9999,
+    elevation: 9999,
+    backgroundColor: "transparent",
+  },
+
+  paymentWrap: {
+    flex: 1,
+  },
+});


### PR DESCRIPTION
- 주문 내역 일부가 이름에서 일관성이 없는 문제로 이미지가 불러와지지 않는 에러 해결
- 카카오페이 결제창에서 진행하지 않고 앱으로 다시 돌아오면 카카오페이 진행 화면에서 이동하지 못하는 문제 해결(헤더 추가)
- 노출된 앱 키 재발급(깃허브에 반영x)